### PR TITLE
Removed cn_variant check for Monero

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -436,8 +436,9 @@ function processShare(miner, job, blockTemplate, nonce, resultHash){
     }
     else {
         convertedBlob = cnUtil.convert_blob(shareBuffer);
-        var cn_variant = isMonero && convertedBlob[0] >= 7 ? convertedBlob[0] - 6 : 0;
-        hash = cryptoNightDark(convertedBlob, cn_variant);
+        //Hardcoded false because this is XCN specific pool code and the code below checks for Monero versions
+        //var cn_variant = isMonero && convertedBlob[0] >= 7 ? convertedBlob[0] - 6 : 0;
+        hash = cryptoNightDark(convertedBlob, false);
         shareType = 'valid';
     }
 


### PR DESCRIPTION
This portion of the code was for Monero only and checked to see what version it was on. Not needed for XCN